### PR TITLE
Fix IAM permission issues on creation of new task

### DIFF
--- a/source/constructs/lib/cfn-step-functions.ts
+++ b/source/constructs/lib/cfn-step-functions.ts
@@ -202,6 +202,7 @@ export class CloudFormationStateMachine extends cdk.Construct {
             "ecs:ListTasks",
             "ecs:RegisterTaskDefinition",
             "ecs:DeregisterTaskDefinition",
+            "ecs:DescribeTaskDefinition",
           ],
           resources: [`*`]
         }),
@@ -320,6 +321,14 @@ export class CloudFormationStateMachine extends cdk.Construct {
             "ecr:GetAuthorizationToken"
           ],
           resources: [`*`]
+        }),
+        new iam.PolicyStatement({
+          actions: [
+            "iam:CreateServiceLinkedRole",
+          ],
+          resources: [
+            `arn:${cdk.Aws.PARTITION}:iam::${cdk.Aws.ACCOUNT_ID}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling`
+          ]
         }),
       ]
     });


### PR DESCRIPTION
**Description of changes:**
- Adds additional IAM permission `ecs:CreateServiceLinkedRole` to existing policy statement within `APICfnWorkflowTaskFnPolicy`.
- Creates new policy statement within `APICfnWorkflowTaskFnPolicy` to grant the `DataTransferHub-APICfnWorkflowCreateTaskCfnFnServi-<ID>` role `iam:CreateServiceLinkedRole` permissions to the `AWSServiceRoleForAutoScaling` resource.

**Why are these changes necessary?**
Without these permissions, the CloudFormation template deployed on creation of a new data transfer task will not successfully deploy and the permissions need to be manually added to the `APICfnWorkflowTaskFnPolicy` attached to the `DataTransferHub-APICfnWorkflowCreateTaskCfnFnServi-<ID>` role.


