### PR TITLE
added assetDomain locations for govcloud partition

### DIFF
--- a/source/constructs/lib/s3-plugin/ec2-finder-stack.ts
+++ b/source/constructs/lib/s3-plugin/ec2-finder-stack.ts
@@ -133,6 +133,9 @@ export class Ec2FinderStack extends Construct {
             'aws-cn': {
                 assetDomain: 'https://aws-gcr-solutions-assets.s3.cn-northwest-1.amazonaws.com.cn',
             },
+            'aws-us-gov': {
+                assetDomain: 'https://aws-gcr-solutions-assets.s3.amazonaws.com',
+            },
         }
     });
 

--- a/source/constructs/lib/s3-plugin/ec2-worker-stack.ts
+++ b/source/constructs/lib/s3-plugin/ec2-worker-stack.ts
@@ -171,6 +171,9 @@ export class Ec2WorkerStack extends Construct {
             'aws-cn': {
                 assetDomain: 'https://aws-gcr-solutions-assets.s3.cn-northwest-1.amazonaws.com.cn',
             },
+            'aws-us-gov': {
+                assetDomain: 'https://aws-gcr-solutions-assets.s3.amazonaws.com',
+            },
         }
     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
s3 plugin for data transfer hub currently fails to deploy in govcloud, as it has no specific asset domain for aws-us-gov partition space. two options here:
1. commit this pull request as is (which leverages using the commercial repo to pull down assets)
2. update code to point to the govcloud specific repo, and deploy underlying assets there

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
